### PR TITLE
chore(meetings.html): update meeting location

### DIFF
--- a/meetings.html
+++ b/meetings.html
@@ -83,7 +83,7 @@ a {
 <div class="content" id="content">
 <h2>Meetings</h2>
 <p>DATE: Second Tuesday of every month at 6PM PT/ 9PM ET.</p>
-<p>Location: Zoom</p>
+<p>Location: virtual/video chat (URL will be provided on Discord in #ha-meeting)</p>
 <h3>Format</h3>
 <p>Meetings are 3 hours maximum and are loosely organized.</p>
 <p><strong>Workflow</strong></p>


### PR DESCRIPTION
chore(meetings.html): update meeting location to virtual/video chat with URL provided on Discord

The meeting location has been changed from "Zoom" to "virtual/video chat". The URL for the chat will now be provided on Discord in the #ha-meeting channel. This change allows for more flexibility in choosing the platform for the meetings.